### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@ This code replicates the results from the paper “Deep metric learning using Tr
 
 It can train a TripletNet on any of the {Cifar10/100, STL10, SVHN, MNIST} datasets.
 
-##Data
+## Data
 You can get the needed data using the following repos:
 * CIFAR10/100: https://github.com/soumith/cifar.torch.git
 * STL10: https://github.com/eladhoffer/stl10.torch
 * SVHN: https://github.com/torch/tutorials/blob/master/A_datasets/svhn.lua
 * MNIST: https://github.com/andresy/mnist
 
-##Dependencies
+## Dependencies
 * Torch (http://torch.ch)
 * "eladtools" (https://github.com/eladhoffer/eladtools) for optimizer.
 * "nngraph" (https://github.com/torch/nngraph) for TripletNet configuration.
 * "cudnn.torch" (https://github.com/soumith/cudnn.torch) for faster training. Can be avoided by changing "cudnn" to "nn" in models.
 
-##Models
+## Models
 Available models are at the “Models” directory. The basic Model.lua was used in the paper, while NiN based models achieve slightly better
 results.
 
-##Training
+## Training
 You can start training using:
 ```lua
 th Main.lua -dataset Cifar10 -LR 0.1 -save new_exp_dir
 ```
 
-##Additional flags
+## Additional flags
 |Flag             | Default Value        |Description
 |:----------------|:--------------------:|:----------------------------------------------
 |modelsFolder     |  ./Models/           | Models Folder


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
